### PR TITLE
implement api routes

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,0 +1,77 @@
+"""
+Registers API routes for the webui
+"""
+import gradio as gr
+from fastapi import FastAPI, Form
+from pydantic import BaseModel
+from typing import List, Optional, Tuple, Union
+import threading
+from scripts.civitaiapi import download_file_thread
+
+
+### ====================classes========================
+class DownloadRequestResponse(BaseModel):
+    """
+    Basic model download response
+    """
+    message:str
+    success:bool
+
+### ====================functions======================
+def assert_download_conditions(url:str, file_name:str, content_type:str, use_new_folder:bool, model_name:Optional[str]=None) -> Union[DownloadRequestResponse, Tuple]:
+    """
+    Asserts conditions for download. Returns DownloadRequestResponse if conditions not met, else returns refined args
+    """
+    if not url:
+        return DownloadRequestResponse(message="No URL provided", success=False)
+    if not file_name:
+        return DownloadRequestResponse(message="No file name provided", success=False)
+    # check content_type in Checkpoint, Hypernetwork, TextualInversion, AestheticGradient, VAE, LORA, LoCon
+    if content_type not in ["Checkpoint", "Hypernetwork", "TextualInversion", "AestheticGradient", "VAE", "LORA", "LoCon"]:
+        return DownloadRequestResponse(
+            message=f"Invalid content type, given {content_type} but expected one of ['Checkpoint', 'Hypernetwork', 'TextualInversion', 'AestheticGradient', 'VAE', 'LORA', 'LoCon']", success=False)
+    if not model_name:
+        # remove ext from file name
+        if "." in file_name:
+            model_name = file_name[:file_name.rindex(".")]
+        else:
+            model_name = file_name
+    return url, file_name, content_type, use_new_folder, model_name
+
+def wrapped_download_file_thread(url:str, model_name:str, file_name:str, content_type:str, use_new_folder:bool=False, wait:bool=False) -> DownloadRequestResponse:
+    """
+    Wraps download_file_thread to return DownloadRequestResponse
+    """
+    assert_download_conditions_response = assert_download_conditions(url, file_name, content_type, use_new_folder, model_name)
+    if isinstance(assert_download_conditions_response, DownloadRequestResponse):
+        return assert_download_conditions_response
+    url, file_name, content_type, use_new_folder, model_name = assert_download_conditions_response
+    thread:threading.Thread = download_file_thread(url, file_name, content_type, use_new_folder, model_name) # started thread
+    if wait:
+        thread.join()
+        return DownloadRequestResponse(message=f"Downloaded {model_name}", success=True)
+    return DownloadRequestResponse(message=f"Downloading {model_name}...", success=True)
+
+def register_download_api(app:FastAPI):
+    @app.post("/download/model", response_model=DownloadRequestResponse)
+    def download_model(url:str=Form(""), model_name:str=Form(""), file_name:str=Form(""), content_type:str=Form(""), use_new_folder:bool=Form(False), wait:bool=Form(False)):
+        """
+        Download a model from a URL
+        example : curl -X POST "http://localhost:7860/download/model" -H "accept: application/json" -H "Content-Type: multipart/form-data" -F "url=https://www.example.com/model.zip" -F "model_name=example_model" -F "file_name=example_model.zip" -F "content_type=Checkpoint" -F "use_new_folder=false" -F "wait=false"
+        """
+        return wrapped_download_file_thread(url, model_name, file_name, content_type, use_new_folder, wait)
+
+def register_api(_:gr.Blocks, app:FastAPI):
+    """
+    Registers hooks for app on webui startup
+    """
+    register_download_api(app)
+
+
+# only works in context of sdwebui
+try:
+    import modules.script_callbacks as script_callbacks
+
+    script_callbacks.on_app_started(register_api)
+except (ImportError, ModuleNotFoundError) as e:
+    print("Could not bind uploader-api to app")

--- a/scripts/civitaiapi.py
+++ b/scripts/civitaiapi.py
@@ -174,6 +174,16 @@ def replace_invalid_chars(file_name):
     return ''.join(c for c in first_processed if c not in r'<>:"/\|?*')
 
 def download_file_thread(url, file_name, content_type, use_new_folder, model_name):
+    """
+    Download the file and save it to a local file
+    
+    @param url:string The URL of the file to download, example) https://example.com/file.txt (may or may not contain file name)
+    @param file_name:string The name of the file to save the download to example) file.txt
+    @param content_type:string The type of content being downloaded, example) Checkpoint, Hypernetwork, TextualInversion, AestheticGradient, VAE, LORA, LoCon
+    @param use_new_folder:boolean Whether to save the file to a new folder or not (default: False)
+    @param model_name:string The name of the model being downloaded, used for subfolder (default: None or use file_name)
+
+    """
     model_name = replace_invalid_chars(model_name)
     if content_type == "Checkpoint":
         folder = "models/Stable-diffusion"
@@ -190,12 +200,9 @@ def download_file_thread(url, file_name, content_type, use_new_folder, model_nam
     elif content_type == "VAE":
         folder = "models/VAE"
         new_folder = "models/VAE/new"
-    elif content_type == "LORA":
+    elif content_type == "LORA" or content_type == "LoCon":
         folder = "models/Lora"
         new_folder = "models/Lora/new"
-    elif content_type == "LoCon":
-        folder = "models/LyCORIS"
-        new_folder = "models/LyCORIS/new"
     if content_type == "TextualInversion" or content_type == "VAE" or content_type == "AestheticGradient":
         if use_new_folder:
             model_folder = new_folder
@@ -225,6 +232,7 @@ def download_file_thread(url, file_name, content_type, use_new_folder, model_nam
 
         # Start the thread
     thread.start()
+    return thread # return the thread so we can wait for it to finish if we want
 
 def save_text_file(file_name, content_type, use_new_folder, trained_words, model_name):
     model_name = replace_invalid_chars(model_name)


### PR DESCRIPTION
This allows API access to internal model downloads.

example:
The example is tested with CuteYukiMix in CivitAI (at least sfw 2d model that won't ban the colab)
```curl -X POST "https://<ADDRESS>/download/model" -H "accept: application/json" -H "Content-Type: multipart/form-data" -F "url=https://civitai.com/api/download/models/163923" -F "model_name=CuteYuki" -F "file_name=CuteYuki.safetensors" -F "content_type=Checkpoint" -F "use_new_folder=false" -F "wait=false"```